### PR TITLE
esedbtools: let reported table number match the filename

### DIFF
--- a/esedbtools/export_handle.c
+++ b/esedbtools/export_handle.c
@@ -4422,22 +4422,16 @@ int export_handle_export_file(
 
 			table_exported = 1;
 		}
-		fprintf(
-		 export_handle->notify_stream,
-		 "Exporting table %d (%" PRIs_SYSTEM ")",
-		 table_index + 1,
-		 table_name );
-
 		if( export_table_name == NULL )
 		{
-			fprintf(
-			 export_handle->notify_stream,
-			 " out of %d",
-			 number_of_tables );
+			fprintf(export_handle->notify_stream,
+				"[%d/%d] ", table_index + 1, number_of_tables);
 		}
 		fprintf(
 		 export_handle->notify_stream,
-		 ".\n" );
+		 "Exporting table to %" PRIs_SYSTEM ".%d\n",
+		 table_name,
+		 table_index );
 
 /* TODO move into export_handle_export_table */
 


### PR DESCRIPTION
esedbexport says ``Exporting table 1 (MSysObjects) out of 1007``, but the filename is called ``MSysObjects.0``.

I figured 1 out of 1007 was meant as a progress counter more than anything else, so I put that in front as [1/1007], and then show the full generated filename afterwards.
