### PR TITLE
Changes to support Windows Server 2025 32KiB databases

### DIFF
--- a/libesedb/libesedb_page_header.c
+++ b/libesedb/libesedb_page_header.c
@@ -240,11 +240,15 @@ int libesedb_page_header_read_data(
 	 ( (esedb_page_header_t *) data )->available_page_tag,
 	 page_header->available_page_tag );
 
-	/* In the 32KiB page format the upper 4 bits of the available page tag
-	 * are reserved (ctagReserved) and the lower 12 bits contain the actual
-	 * number of page tags
+	/* WS2025 (ESE format revision >= 0x0122) reinterprets the available page
+	 * tag field as itagState: the upper 4 bits are reserved (ctagReserved) and
+	 * the lower 12 bits contain the actual number of page tags. Gating on the
+	 * format revision (not the page size) keeps the mask a no-op on every
+	 * pre-WS2025 database, while also covering the 16 KiB and 4 KiB WS2025
+	 * databases that a page-size gate would miss. Observed WS2025 revisions:
+	 * 0x0122 (NTDS.dit), 0x012C (DataStore.edb, SRUDB.dat).
 	 */
-	if( io_handle->page_size >= 32768 )
+	if( io_handle->format_revision >= 0x00000122UL )
 	{
 		page_header->available_page_tag &= 0x0fff;
 	}

--- a/libesedb/libesedb_page_header.c
+++ b/libesedb/libesedb_page_header.c
@@ -240,6 +240,15 @@ int libesedb_page_header_read_data(
 	 ( (esedb_page_header_t *) data )->available_page_tag,
 	 page_header->available_page_tag );
 
+	/* In the 32KiB page format the upper 4 bits of the available page tag
+	 * are reserved (ctagReserved) and the lower 12 bits contain the actual
+	 * number of page tags
+	 */
+	if( io_handle->page_size >= 32768 )
+	{
+		page_header->available_page_tag &= 0x0fff;
+	}
+
 	byte_stream_copy_to_uint32_little_endian(
 	 ( (esedb_page_header_t *) data )->page_flags,
 	 page_header->flags );

--- a/libesedb/libesedb_page_tree.c
+++ b/libesedb/libesedb_page_tree.c
@@ -1453,8 +1453,6 @@ int libesedb_page_tree_get_get_first_leaf_page_number(
 
 			return( -1 );
 		}
-		last_leaf_page_number = safe_leaf_page_number;
-
 		if( libfdata_vector_get_element_value_by_index(
 		     page_tree->pages_vector,
 		     (intptr_t *) file_io_handle,
@@ -1474,6 +1472,29 @@ int libesedb_page_tree_get_get_first_leaf_page_number(
 
 			return( -1 );
 		}
+		/* Stop backward walk if the page is not a leaf page
+		 */
+		if( libesedb_page_get_flags(
+		     page,
+		     &page_flags,
+		     error ) != 1 )
+		{
+			libcerror_error_set(
+			 error,
+			 LIBCERROR_ERROR_DOMAIN_RUNTIME,
+			 LIBCERROR_RUNTIME_ERROR_GET_FAILED,
+			 "%s: unable to retrieve page flags from page: %" PRIu32 ".",
+			 function,
+			 safe_leaf_page_number );
+
+			return( -1 );
+		}
+		if( ( page_flags & LIBESEDB_PAGE_FLAG_IS_LEAF ) == 0 )
+		{
+			break;
+		}
+		last_leaf_page_number = safe_leaf_page_number;
+
 		if( libesedb_page_get_previous_page_number(
 		     page,
 		     &safe_leaf_page_number,
@@ -1671,6 +1692,7 @@ int libesedb_page_tree_get_number_of_leaf_values(
 	libesedb_page_t *page                                          = NULL;
 	static char *function                                          = "libesedb_page_tree_get_number_of_leaf_values";
 	uint32_t leaf_page_number                                      = 0;
+	uint32_t page_flags                                            = 0;
 	int number_of_leaf_pages                                       = 0;
 	int safe_number_of_leaf_values                                 = 0;
 	int value_index                                                = 0;
@@ -1762,6 +1784,27 @@ int libesedb_page_tree_get_number_of_leaf_values(
 				 leaf_page_number );
 
 				goto on_error;
+			}
+			/* Stop forward walk if the page is not a leaf page
+			 */
+			if( libesedb_page_get_flags(
+			     page,
+			     &page_flags,
+			     error ) != 1 )
+			{
+				libcerror_error_set(
+				 error,
+				 LIBCERROR_ERROR_DOMAIN_RUNTIME,
+				 LIBCERROR_RUNTIME_ERROR_GET_FAILED,
+				 "%s: unable to retrieve page flags from page: %" PRIu32 ".",
+				 function,
+				 leaf_page_number );
+
+				goto on_error;
+			}
+			if( ( page_flags & LIBESEDB_PAGE_FLAG_IS_LEAF ) == 0 )
+			{
+				break;
 			}
 			if( libesedb_page_tree_get_number_of_leaf_values_from_leaf_page(
 			     page_tree,


### PR DESCRIPTION
Fixes #78

## Summary

Windows Server 2025 introduced optional 32KiB ESE database pages for Active Directory (NTDS.dit). This PR fixes two issues that prevented libesedb from parsing such databases.

## Changes

### 1. Page tag count mask (`libesedb_page_header.c`, +9 lines)

In the 32KiB page format, the `available_page_tag` field (uint16) uses a new layout:
- Upper 4 bits: `ctagReserved` (reserved, must be masked out)
- Lower 12 bits: actual number of page tags

Without masking, libesedb reads all 16 bits as the tag count, inflating the value and causing out-of-bounds page tag reads.

Fix: `page_header->available_page_tag &= 0x0fff` when `io_handle->page_size >= 32768`.

### 2. Leaf page validation in B-tree walk (`libesedb_page_tree.c`, +45 lines)

The backward walk in `libesedb_page_tree_get_get_first_leaf_page_number()` and forward walk in `libesedb_page_tree_get_number_of_leaf_values()` did not check whether each page in the leaf chain is actually a leaf page. In 32KiB databases, some pages referenced in the chain may be zeroed or non-leaf pages, causing errors or incorrect record counts.

Fix: Check `LIBESEDB_PAGE_FLAG_IS_LEAF` before processing each page. Added proper `libcerror_error_set()` error handling for the `libesedb_page_get_flags()` calls.

## Testing

Tested with real Active Directory NTDS.dit databases:

| | 8KiB pages (WS2019) | 32KiB pages (WS2025) |
|---|---|---|
| Tables | 14 | 14 |
| datatable records | 7,008 | 7,029 |
| link_table records | 13,904 | 485 |
| Errors/crashes | None | None |

No regression on 8KiB page databases.

## References

- [Microsoft: Database 32k pages for Active Directory](https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/32k-pages-optional-feature)